### PR TITLE
x86: Always put snippets-rodata into regular rodata section

### DIFF
--- a/include/zephyr/arch/x86/ia32/linker.ld
+++ b/include/zephyr/arch/x86/ia32/linker.ld
@@ -225,8 +225,6 @@ SECTIONS
 		*(.pinned_rodata)
 		*(.pinned_rodata.*)
 
-#include <snippets-rodata.ld>
-
 #include <zephyr/linker/kobject-rom.ld>
 
 		MMU_PAGE_ALIGN_PERM
@@ -372,12 +370,12 @@ SECTIONS
 #endif /* !CONFIG_LINKER_USE_PINNED_SECTION */
 #endif /* CONFIG_DYNAMIC_INTERRUPTS */
 
-#ifndef CONFIG_LINKER_USE_PINNED_SECTION
 /* Located in generated directory. This file is populated by the
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-rodata.ld>
 
+#ifndef CONFIG_LINKER_USE_PINNED_SECTION
 #include <zephyr/linker/kobject-rom.ld>
 #endif
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)


### PR DESCRIPTION
Always put the inclusion of snippets-rodata.ld into the normal rodata section no matter pinned sections are used or not. No reason to put it in pinned sections.